### PR TITLE
石の数表示機能の追加

### DIFF
--- a/Assets/Documentation/Feature_StoneCount_Implementation.txt
+++ b/Assets/Documentation/Feature_StoneCount_Implementation.txt
@@ -1,0 +1,85 @@
+# 石の数表示機能の実装記録
+
+## 実装日時
+2025年8月2日
+
+## 作業時間
+約10分
+
+## ブランチ
+feature/develop/#q3_stonecount
+
+## 実装内容
+1. TextMeshProUGUIコンポーネント参照の追加
+   - `[SerializeField] private TextMeshProUGUI _stoneCountText`を追加
+   - インスペクターから設定可能に
+
+2. 石の数カウント機能の追加
+   - `UpdateStoneCount`メソッドを追加
+   - 盤面全体をスキャンして白と黒の石の数を集計
+   - "白: X 黒: Y" の形式で表示
+
+3. 更新タイミングの実装
+   - ゲーム開始時
+   - プレイヤーが石を置いた後
+   - AIが石を置いた後
+
+## 更新タイミング
+- ゲーム開始時（Start時）
+- 石を置いた後（プレイヤー、AI共に）
+- ひっくり返し処理の後
+
+## 必要な作業
+1. UIにTextMeshProUGUIコンポーネントを配置
+2. GameControllerのインスペクターで_stoneCountTextを設定
+
+## テスト項目
+- [ ] ゲーム開始時に正しく石の数が表示されるか（白2、黒2）
+- [ ] プレイヤーが石を置いた後、正しく数が更新されるか
+- [ ] AIが石を置いた後、正しく数が更新されるか
+- [ ] ひっくり返した石も正しくカウントされているか
+- [ ] テキストが見やすい位置に表示されているか
+
+## コード変更内容
+```csharp
+// 変数の追加
+[SerializeField]
+private TextMeshProUGUI _stoneCountText = default;
+
+// UpdateStoneCountメソッドの追加
+private void UpdateStoneCount()
+{
+    int whiteCount = 0;
+    int blackCount = 0;
+    
+    // 全マスを走査して石の数を数える
+    for (int y = 0; y < 8; y++)
+    {
+        for (int x = 0; x < 8; x++)
+        {
+            if (_massObjects[y, x] != default)
+            {
+                if (_massObjects[y, x].State == MassState.WHITE)
+                    whiteCount++;
+                else if (_massObjects[y, x].State == MassState.BLACK)
+                    blackCount++;
+            }
+        }
+    }
+    
+    _stoneCountText.text = $"白: {whiteCount}  黒: {blackCount}";
+}
+
+// 呼び出し箇所
+void Start()
+{
+    // 既存の処理
+    UpdateStoneCount(); // 初期状態での石の数を表示
+}
+
+// Update内のターン切り替え時
+_isPlayerTurn = !_isPlayerTurn;
+UpdateCanPut();
+UpdateTurnText();
+UpdateStoneCount(); // 石の数の更新
+```

--- a/Assets/Documentation/Feature_StoneCount_Implementation.txt.meta
+++ b/Assets/Documentation/Feature_StoneCount_Implementation.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a55ebc1bced724a5d9f05a040619ccaf
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2511,6 +2511,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1803636368}
+  - {fileID: 659309936}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2884,6 +2885,142 @@ Transform:
   m_Children: []
   m_Father: {fileID: 784788772}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &659309935
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 659309936}
+  - component: {fileID: 659309938}
+  - component: {fileID: 659309937}
+  m_Layer: 5
+  m_Name: Text (TMP) (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &659309936
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 659309935}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 593569516}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 449.2, y: -201}
+  m_SizeDelta: {x: 800, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &659309937
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 659309935}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 1e43dbac2d24f453f887926e03ca4bcb, type: 2}
+  m_sharedMaterial: {fileID: 705556028757877221, guid: 1e43dbac2d24f453f887926e03ca4bcb, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 80
+  m_fontSizeBase: 80
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &659309938
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 659309935}
+  m_CullTransparentMesh: 1
 --- !u!1 &679641910
 GameObject:
   m_ObjectHideFlags: 0
@@ -3782,6 +3919,7 @@ MonoBehaviour:
   _stonePrefab: {fileID: 6272355897021089887, guid: 7741d21a19ef4429da310ff48e7f1dae, type: 3}
   _highlightPrefab: {fileID: 1753760643659414575, guid: 1ea98c72e58f64b3a8fac7de11f6c896, type: 3}
   _turnText: {fileID: 1803636369}
+  _stoneCountText: {fileID: 659309937}
 --- !u!1 &1028126059
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -26,6 +26,8 @@ public class GameController : MonoBehaviour
     private GameObject _highlightPrefab = default;
     [SerializeField]
     private TextMeshProUGUI _turnText = default;
+    [SerializeField]
+    private TextMeshProUGUI _stoneCountText = default;
     private bool _isPlayerTurn = true;
     private List<Vector2Int> _canPutMass = new List<Vector2Int>(16);
     private List<GameObject> _highlightObjects = new List<GameObject>();
@@ -37,6 +39,7 @@ public class GameController : MonoBehaviour
         PutStone(new Vector2Int(4, 4), MassState.WHITE);
         UpdateCanPut(); // 初期状態でのハイライトを表示
         UpdateTurnText(); // 初期状態でのターン表示
+        UpdateStoneCount(); // 初期状態での石の数を表示
     }
     void Update()
     {
@@ -50,6 +53,7 @@ public class GameController : MonoBehaviour
                 _isPlayerTurn = !_isPlayerTurn;
                 UpdateCanPut();
                 UpdateTurnText();
+                UpdateStoneCount();
             }
         }
         else
@@ -75,6 +79,7 @@ public class GameController : MonoBehaviour
                         _isPlayerTurn = !_isPlayerTurn;
                         UpdateCanPut();
                         UpdateTurnText();
+                        UpdateStoneCount();
                     }
                 }
             }
@@ -173,6 +178,30 @@ public class GameController : MonoBehaviour
     {
         _turnText.text = _isPlayerTurn ? "あなたのターン" : "AIのターン";
     }
+
+    private void UpdateStoneCount()
+    {
+        int whiteCount = 0;
+        int blackCount = 0;
+        
+        // 全マスを走査して石の数を数える
+        for (int y = 0; y < 8; y++)
+        {
+            for (int x = 0; x < 8; x++)
+            {
+                if (_massObjects[y, x] != default)
+                {
+                    if (_massObjects[y, x].State == MassState.WHITE)
+                        whiteCount++;
+                    else if (_massObjects[y, x].State == MassState.BLACK)
+                        blackCount++;
+                }
+            }
+        }
+        
+        _stoneCountText.text = $"白: {whiteCount}  黒: {blackCount}";
+    }
+
     private void UpdateCanPut()
     {
         _canPutMass.Clear();


### PR DESCRIPTION
# 概要
リバーシゲームにおいて、白と黒それぞれの石の数を画面上に表示する機能を追加しました。

## 変更内容
- TextMeshProUGUI コンポーネント参照の追加
- 以下のタイミングで石の数を更新するように実装
  - ゲーム開始時
  - プレイヤーが石を置いた後
  - AIが石を置いた後
- 実装の詳細を記録したドキュメントを追加

## 表示内容
- 白の石の数と黒の石の数を"白: X 黒: Y"の形式で表示
- 石をひっくり返した後も正しく数が更新される

## テスト項目
- [ ] ゲーム開始時に正しく石の数が表示されるか（白2、黒2）
- [ ] プレイヤーが石を置いた後、正しく数が更新されるか
- [ ] AIが石を置いた後、正しく数が更新されるか
- [ ] ひっくり返した石も正しくカウントされているか
- [ ] テキストが見やすい位置に表示されているか

## 注意事項
- UIの設定が必要です
  - Canvas上にTextMeshProUGUIコンポーネントを配置
  - GameControllerの`_stoneCountText`にTextMeshProUGUIコンポーネントを設定